### PR TITLE
Fix NatSpec Documentation for AidenToken Contract

### DIFF
--- a/AidenToken.sol
+++ b/AidenToken.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MIT
-
-//** Aiden Token */
 pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 
-/// @title Aiden Token
-/// @author Aidenlabs.ai
-/// @dev A token based on OpenZeppelin's principles
-
+/**
+ * @title Aiden Token
+ * @author Aidenlabs.ai
+ * @dev A token based on OpenZeppelin's principles
+ */
 contract AidenToken is ERC20Burnable {
-    /// @notice A constructor that mint the tokens
+    /**
+     * @notice Constructor that mints the tokens
+     */
     constructor() ERC20("Aiden", "ADN") {
         _mint(msg.sender, 4_000_000_000 * 10 ** decimals());
     }


### PR DESCRIPTION
Updated the NatSpec comments in the AidenToken contract to adhere to Solidity documentation standards. The changes include replacing incorrect single-line comments with proper multi-line NatSpec blocks and fixing minor wording issues.